### PR TITLE
Fix ambiguous occurrence 'Options'

### DIFF
--- a/src/Network/Yandex/Translate/Types.hs
+++ b/src/Network/Yandex/Translate/Types.hs
@@ -28,7 +28,7 @@ import Prelude hiding (drop)
 import Data.Default.Class
 import Control.Monad.Trans.Reader
 import Control.Lens
-import Data.Aeson
+import Data.Aeson hiding (Options)
 import Data.Monoid
 import Data.HashMap.Strict
 import Data.Text


### PR DESCRIPTION
Hi! Thanks for the great package. This pull request fixes this error:

```
        Ambiguous occurrence ‘Options’
        It could refer to either ‘Data.Aeson.Options’,
                                 imported from ‘Data.Aeson’ at src/Network/Yandex/Translate/Types.hs:31:1-17
                                 (and originally defined in ‘aeson-1.2.3.0:Data.Aeson.Types.Internal’)
                              or ‘Network.Wreq.Options’,
                                 imported from ‘Network.Wreq’ at src/Network/Yandex/Translate/Types.hs:36:1-36
                                 (and originally defined in ‘wreq-0.5.1.0:Network.Wreq.Internal.Types’)
       |
    52 |     _httpOptions :: Options
       |                     ^^^^^^^
```